### PR TITLE
test: fix tests failing to collect

### DIFF
--- a/rnginline/test/test_rnginline.py
+++ b/rnginline/test/test_rnginline.py
@@ -40,7 +40,7 @@ def _load_testcases():
 
         assert positive_cases
         assert not [f for _files in [[schema], positive_cases, negative_cases]
-                    for f in _files if not pr.resource_exists(__name__, f)]
+                    for f in _files if not pr.resource_exists(TESTPKG, f)]
 
         for file in positive_cases:
             testcases.append((schema, file, True))


### PR DESCRIPTION
`rnginline.test.test_rnginline._load_testcases()` was failing with an error from `pkg_resources` while trying to read package data. The problem is that pytest overrides the `__loader__` of test modules, and `pkg_resources` changes its resource-loading behaviour based on a module's `__loader__`. It doesn't know about pytest's loader, so it fails to find a provider for the module, and blows up when trying to access resources.

Using `rnginline.test` as the module to access resources from avoids this, as it's not a test module, so it uses a normal `__loader__`.

This fixes #3 