### PR TITLE
fix: handle indirectly-included components when overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ and this project adheres to
 
 ### Fixed
 
+- Handle indirectly-included components when overriding (#5)
+
+  Previously when inlining `<include>` elements, the include's override
+  components were only able to override components that directly occurred in the
+  included schema. If the included schema itself didn't directly contain an
+  overridden `<define>` or `<start>` element, but instead included another
+  schema that did contain an overridden element, `rnginline` would fail to find
+  the indirectly-included element(s) and would fail with an error. (Because
+  overrides must match elements in the included schema.)
+
+  Thanks to [takesson](https://github.com/takesson) for reporting this and
+  providing a test case to demonstrate the issue.
+
 - Resolved deprecation warnings from:
   - old string escape syntax
   - `pkg_resources` module (we now use `importlib_resources`)

--- a/rnginline/test/data/testcases/include-override-indirect-combined/level-1-a.rng
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/level-1-a.rng
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="level-2-a.rng"/>
+    <include href="level-2-b.rng"/>
+
+    <define name="animal.attribute" combine="interleave">
+        <optional>
+            <attribute name="age">
+                <text/>
+            </attribute>
+        </optional>
+    </define>
+</grammar>

--- a/rnginline/test/data/testcases/include-override-indirect-combined/level-2-a.rng
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/level-2-a.rng
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <define name="animal.element" combine="choice">
+        <element name="dog">
+            <ref name="animal.attrs"/>
+        </element>
+    </define>
+
+    <define name="animal.element" combine="choice">
+        <element name="sheep">
+            <ref name="animal.attrs"/>
+        </element>
+    </define>
+
+    <define name="animal.attrs" combine="interleave">
+        <optional>
+            <attribute name="name">
+                <text/>
+            </attribute>
+        </optional>
+    </define>
+
+    <define name="animal.attrs" combine="interleave">
+        <optional>
+            <attribute name="colour">
+                <text/>
+            </attribute>
+        </optional>
+    </define>
+
+    <start combine="choice">
+        <element name="removed-via-override-a">
+            <empty/>
+        </element>
+    </start>
+</grammar>

--- a/rnginline/test/data/testcases/include-override-indirect-combined/level-2-b.rng
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/level-2-b.rng
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+    <define name="animal.element" combine="choice">
+        <element name="horse">
+            <ref name="animal.attrs"/>
+        </element>
+    </define>
+
+    <start combine="choice">
+        <element name="removed-via-override-b">
+            <empty/>
+        </element>
+    </start>
+</grammar>

--- a/rnginline/test/data/testcases/include-override-indirect-combined/negative-1.xml
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/negative-1.xml
@@ -1,0 +1,4 @@
+<animals>
+    <pig age="4"/>
+</animals>
+

--- a/rnginline/test/data/testcases/include-override-indirect-combined/negative-2.xml
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/negative-2.xml
@@ -1,0 +1,4 @@
+<animals>
+    <pig name="peewee"/>
+</animals>
+

--- a/rnginline/test/data/testcases/include-override-indirect-combined/negative-3.xml
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/negative-3.xml
@@ -1,0 +1,4 @@
+<animals>
+    <horse/>
+</animals>
+

--- a/rnginline/test/data/testcases/include-override-indirect-combined/negative-4.xml
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/negative-4.xml
@@ -1,0 +1,4 @@
+<animals>
+    <dog/>
+</animals>
+

--- a/rnginline/test/data/testcases/include-override-indirect-combined/negative-5.xml
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/negative-5.xml
@@ -1,0 +1,1 @@
+<removed-via-override-a/>

--- a/rnginline/test/data/testcases/include-override-indirect-combined/negative-6.xml
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/negative-6.xml
@@ -1,0 +1,1 @@
+<removed-via-override-b/>

--- a/rnginline/test/data/testcases/include-override-indirect-combined/positive-1.xml
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/positive-1.xml
@@ -1,0 +1,9 @@
+<animals>
+    <pig favourite-food="slop"/>
+    <rabbit birthday="2022-01-01"/>
+    <goat favourite-food="plastic" birthday="2021-01-01"/>
+    <pig/>
+    <rabbit/>
+    <goat/>
+</animals>
+

--- a/rnginline/test/data/testcases/include-override-indirect-combined/schema.rng
+++ b/rnginline/test/data/testcases/include-override-indirect-combined/schema.rng
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+    <!-- This schema overrides multiple instances of start and define elements with combine. -->
+    <include href="level-1-a.rng">
+        <!-- override the 2 animal.element from layer 2 with these 3 -->
+        <define name="animal.element" combine="choice">
+            <element name="rabbit">
+                <ref name="animal.attrs"/>
+            </element>
+        </define>
+        <define name="animal.element" combine="choice">
+            <element name="goat">
+                <ref name="animal.attrs"/>
+            </element>
+        </define>
+        <define name="animal.element" combine="choice">
+            <element name="pig">
+                <ref name="animal.attrs"/>
+            </element>
+        </define>
+        <!-- override the 2 animal.attribute from layer 1 and 2 -->
+        <define name="animal.attrs" combine="interleave">
+            <optional>
+                <attribute name="favourite-food">
+                    <text/>
+                </attribute>
+            </optional>
+        </define>
+        <define name="animal.attrs" combine="interleave">
+            <optional>
+                <attribute name="birthday">
+                    <text/>
+                </attribute>
+            </optional>
+        </define>
+
+        <!-- Override the 2 combined start rules from level 2 with one -->
+        <start>
+            <element name="animals">
+                <zeroOrMore>
+                    <ref name="animal.element"></ref>
+                </zeroOrMore>
+            </element>
+        </start>
+    </include>
+</grammar>

--- a/rnginline/test/data/testcases/include-override-indirect/level-1-a.rng
+++ b/rnginline/test/data/testcases/include-override-indirect/level-1-a.rng
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <include href="level-2-a.rng">
+        <!-- Important: no redefine of 'content'. -->
+
+        <!-- Redefine atts in intermediate.rng to demonstrate both levels of redefine. -->
+        <define name="atts">
+            <optional><attribute name="a"/></optional>
+        </define>
+    </include>
+</grammar>

--- a/rnginline/test/data/testcases/include-override-indirect/level-2-a.rng
+++ b/rnginline/test/data/testcases/include-override-indirect/level-2-a.rng
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+
+    <start>
+        <element name="start-from-level-2">
+            <empty/>
+        </element>
+    </start>
+
+    <define name="content">
+        <choice>
+            <!-- Allow both 'one' and 'two'. -->
+            <ref name="one.element"/>
+            <ref name="two.element"/>
+        </choice>
+    </define>
+
+    <define name="one.element">
+        <element name="one">
+            <ref name="atts"/>
+            <empty/>
+        </element>
+    </define>
+
+    <define name="two.element">
+        <element name="two">
+            <ref name="atts"/>
+            <empty/>
+        </element>
+    </define>
+
+    <define name="atts">
+        <interleave>
+            <optional><attribute name="a"/></optional>
+            <optional><attribute name="b"/></optional>
+        </interleave>
+    </define>
+</grammar>

--- a/rnginline/test/data/testcases/include-override-indirect/negative-1.xml
+++ b/rnginline/test/data/testcases/include-override-indirect/negative-1.xml
@@ -1,0 +1,5 @@
+<start>
+    <one/>
+    <two/>
+</start>
+

--- a/rnginline/test/data/testcases/include-override-indirect/negative-2.xml
+++ b/rnginline/test/data/testcases/include-override-indirect/negative-2.xml
@@ -1,0 +1,4 @@
+<start>
+    <one b="2"/>
+</start>
+

--- a/rnginline/test/data/testcases/include-override-indirect/negative-3.xml
+++ b/rnginline/test/data/testcases/include-override-indirect/negative-3.xml
@@ -1,0 +1,1 @@
+<start-from-level-2/>

--- a/rnginline/test/data/testcases/include-override-indirect/other.rng
+++ b/rnginline/test/data/testcases/include-override-indirect/other.rng
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+    <define name="other.element">
+        <element name="other">
+            <empty/>
+        </element>
+    </define>
+</grammar>

--- a/rnginline/test/data/testcases/include-override-indirect/positive-1.xml
+++ b/rnginline/test/data/testcases/include-override-indirect/positive-1.xml
@@ -1,0 +1,4 @@
+<start>
+    <one/>
+</start>
+

--- a/rnginline/test/data/testcases/include-override-indirect/positive-2.xml
+++ b/rnginline/test/data/testcases/include-override-indirect/positive-2.xml
@@ -1,0 +1,4 @@
+<start>
+    <one a="1"/>
+</start>
+

--- a/rnginline/test/data/testcases/include-override-indirect/schema.rng
+++ b/rnginline/test/data/testcases/include-override-indirect/schema.rng
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+    <include href="level-1-a.rng">
+        <!-- Both start and the "content" define override things that are not
+             directly in intermediate.rng, they're in common.rng which is
+             included by intermediate.rng. -->
+        <start>
+            <ref name="start.element"/>
+        </start>
+        <define name="content">
+            <ref name="one.element"/>
+        </define>
+    </include>
+
+    <div>
+        <define name="start.element">
+            <element name="start">
+                <ref name="content"></ref>
+            </element>
+        </define>
+    </div>
+</grammar>


### PR DESCRIPTION
Previously when inlining `<include>` elements, the include's override components were only able to override components that directly occurred in the included schema. If the included schema itself didn't directly contain an overridden `<define>` or `<start>` element, but instead included another schema that did contain an overridden element, `rnginline` would fail to find the indirectly-included element(s) and would fail with an error. (Because overrides must match elements in the included schema.)

This occurred because of the deferred XML inclusion workaround we use to lazily merge XML trees. Rather than inserting XML elements from referenced schemas directly into the referencing schema's XML tree, we instead maintain a tree of the positions that included elements need to placed at when the final merging is performed.

When we searched for overridden components, we only looked in the immediate XML root of the schema that was included, without descending into any pending, indirect XML trees. To fix this, we now fully traverse the deferred XML inclusion tree when searching for overridden components.

See issue #5.