### PR TITLE
Get `rnginline.__version__` from package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Nothing yet.
 
 - Supported Python versions are now 3.7 – 3.11 (inclusive)
 - Project codebase & tooling refreshed
+- Get `rnginline.__version__` / `rnginline --version` from package metadata
+  instead of hardcoding it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [1.0.0]
+
 ### Changed
 
 - Supported Python versions are now 3.7 – 3.11 (inclusive)
@@ -15,7 +19,8 @@ and this project adheres to
 
 ### Fixed
 
-- Handle indirectly-included components when overriding (#5)
+- Handle indirectly-included components when overriding
+  ([#5](https://github.com/h4l/rnginline/issues/5))
 
   Previously when inlining `<include>` elements, the include's override
   components were only able to override components that directly occurred in the
@@ -38,13 +43,14 @@ and this project adheres to
 ### Fixed
 
 - Old data file with non-ascii filename was being included in the 0.0.1 build
-  (#2).
+  ([#2](https://github.com/h4l/rnginline/issues/2)).
 
 ## [0.0.1] — 2015-03-29
 
 Initial release
 
 [unreleased]:
-  https://github.com/olivierlacan/keep-a-changelog/compare/0.0.2...HEAD
+  https://github.com/olivierlacan/keep-a-changelog/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/h4l/rnginline/compare/0.0.2...1.0.0
 [0.0.2]: https://github.com/h4l/rnginline/compare/0.0.1...0.0.2
 [0.0.1]: https://github.com/h4l/rnginline/releases/tag/0.0.1

--- a/poetry.lock
+++ b/poetry.lock
@@ -437,7 +437,7 @@ files = [
 name = "importlib-metadata"
 version = "6.6.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1502,7 +1502,7 @@ files = [
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1517,4 +1517,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "c11c90a51c711e9650768efdf454d893b2ebca364cecdfa4279ac52a281094a0"
+content-hash = "5d000071970c6a55ab0d32ec8d74f88f4ca1c56c580d3b090848d1fdf58f58e9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ docopt-ng = "^0.8.1"
 lxml = "^4"
 python = "^3.7"
 typing-extensions = "^4.5.0"
+importlib-metadata = "^6.6.0"
 
 [tool.poetry.group.dev.dependencies]
 tox = "^3.25.1"

--- a/rnginline/__init__.py
+++ b/rnginline/__init__.py
@@ -23,6 +23,7 @@ from typing import (
     overload,
 )
 
+from importlib_metadata import version
 from lxml import etree
 from typing_extensions import Final, Literal, Protocol
 
@@ -43,7 +44,7 @@ from rnginline.exceptions import (
     SchemaIncludesSelfError,
 )
 
-__version__ = "0.0.2"
+__version__ = version("rnginline")
 
 __all__ = ["inline", "Inliner"]
 


### PR DESCRIPTION
`rnginline.__version__` used by `rnginline.cmdline` for `--version` is now obtained from the package metadata, instead of hardcoding it. So it'll update automatically as the version in pyproject.toml changes.